### PR TITLE
Add descriptions for prboom and pc (dosbox)

### DIFF
--- a/lang/en.xml
+++ b/lang/en.xml
@@ -182,7 +182,7 @@
 	<gc>The GameCube is Nintendo's entry in the sixth generation of video game consoles and is the successor to their previous console, the Nintendo 64. The GameCube competed with Sony's PlayStation 2 and Microsoft's Xbox.</gc>
 	<mplayer> </mplayer>
 	<msx2>MSX is a standardized home computer architecture, announced by Microsoft and ASCII on June 16, 1983. It was initially conceived by Microsoft as a product for the Eastern sector, and jointly marketed by Kazuhiko Nishi, then vice-president at Microsoft and director at ASCII Corporation.</msx2>
-	<pc> </pc>
+	<pc>DOSBox is a free and open-source emulator which runs software for MS-DOS compatible disk operating systems - primarily video games. It was first released in 2002, when DOS technology was becoming obsolete.</pc>
 	<pce-cd>TurboGrafx-16, fully titled as TurboGrafx-16 Entertainment SuperSystem and known in Japan as the PC Engine, is a video game console developed by Hudson Soft and NEC, released in Japan on October 30, 1987, and in North America on August 29, 1989.</pce-cd>
 	<pokemini>The Pokémon Mini is a handheld game console that was designed and manufactured by Nintendo and themed around the Pokémon media franchise. It is the smallest game system with interchangeable cartridges ever produced by Nintendo.</pokemini>
 	<pspminis>PSP Minis are 100MB or smaller digital games that launched alongside the PSPgo. In total 290 Mini's games were released.</pspminis>

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -179,6 +179,7 @@
 	<atari800>The Atari 8-bit family is a series of 8-bit home computers introduced by Atari, Inc. in 1979 as the Atari 400 and Atari 800 and manufactured until 1992. All of the machines in the family are technically similar and differ primarily in packaging.</atari800>
 	<daphne>Daphne is an arcade game emulator for Windows, Linux and Mac OS X, developed by Matt Ownby. It runs games for several LaserDisc-based systems, including most Sega LaserDisc hardware games. </daphne>
 	<fbneo>Final Burn Neo is an Emulator for Arcade Games and Select Consoles. It is based on the emulators FinalBurn and old versions of MAME.</fbneo>
+	<prboom>Doom is a video game franchise that saw its first release in 1993. The series focuses on the exploits of an unnamed space marine operating under the auspices of the Union Aerospace Corporation (UAC), who fights hordes of demons and the undead.</prboom>
 	<gc>The GameCube is Nintendo's entry in the sixth generation of video game consoles and is the successor to their previous console, the Nintendo 64. The GameCube competed with Sony's PlayStation 2 and Microsoft's Xbox.</gc>
 	<mplayer> </mplayer>
 	<msx2>MSX is a standardized home computer architecture, announced by Microsoft and ASCII on June 16, 1983. It was initially conceived by Microsoft as a product for the Eastern sector, and jointly marketed by Kazuhiko Nishi, then vice-president at Microsoft and director at ASCII Corporation.</msx2>

--- a/systems/pc.xml
+++ b/systems/pc.xml
@@ -20,7 +20,7 @@
    <text></text>
   </text>
 		<text name="description" extra="true">
-			<text></text>
+			<text>${pc}</text>
 		</text>
 		
 	</view>

--- a/systems/prboom.xml
+++ b/systems/prboom.xml
@@ -1,1 +1,27 @@
-doom.xml
+<theme>
+	<formatVersion>4</formatVersion>
+
+	<view name="system">	
+
+        <image name="art" extra="true">
+         <origin>0 0</origin>
+         <pos>0 0</pos>
+         <size>1 1</size>
+      </image>	
+
+    <image name="background" extra="true">
+      </image> 
+
+	<image name="console" extra="true">
+    </image>
+
+
+	 <text name="shortdescription" extra="true">
+<text>Game Collection</text>
+  </text>
+		<text name="description" extra="true">
+			<text>${prboom}</text>
+		</text>
+		
+	</view>
+</theme>


### PR DESCRIPTION
The system "Doom" is defined as "prboom" in EmuELEC. "prboom" in Crystal references "doom", which is defined as a collection. In the end the text for doom does not appear, so i de-referenced doom and made "prboom" its own system with own xml-file.
The description for pc (dosbox) was missing.